### PR TITLE
Correct serialization of floating point numbers for Python 2

### DIFF
--- a/pyorient/ogm/property.py
+++ b/pyorient/ogm/property.py
@@ -98,7 +98,11 @@ class PropertyEncoder:
     @staticmethod
     def encode_value(value):
         if isinstance(value, decimal.Decimal):
-            return repr(str(value))
+            return u'"{:f}"'.format(value)
+        elif isinstance(value, float):
+            with decimal.localcontext() as ctx:
+                ctx.prec = 20  # floats are max 80-bits wide = 20 significant digits
+                return u'"{:f}"'.format(decimal.Decimal(value))
         elif isinstance(value, datetime.datetime) or isinstance(value, datetime.date):
             return u'"{}"'.format(value)
         elif isinstance(value, str):

--- a/pyorient/serializations.py
+++ b/pyorient/serializations.py
@@ -1,7 +1,7 @@
 import sys
 import time
 from datetime import date, datetime
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from .otypes import OrientRecordLink, OrientRecord, OrientBinaryObject
 from .exceptions import PyOrientBadMethodCallException
 
@@ -114,25 +114,24 @@ class OrientSerializationCSV(object):
         if isinstance(value, str):
             ret = '"' + value + '"'
         elif isinstance(value, float):
-            ret = str(value) + 'd'
-
+            with localcontext() as ctx:
+                ctx.prec = 20  # floats are max 80-bits wide = 20 significant digits
+                ret = '{:f}d'.format(Decimal(value))
         elif sys.version_info[0] >= 3 and isinstance(value, int):
             if value > 2147483647:
                 ret = str(value) + 'l'
             else:
                 ret = str(value)
-
         elif sys.version_info[0] < 3 and isinstance(value, long):
             ret = str(value) + 'l'
         elif isinstance(value, int):
             ret = str(value)
-
         elif isinstance(value, datetime):
             ret = str(int(time.mktime(value.timetuple())) * 1000) + 't'
         elif isinstance(value, date):
             ret = str(int(time.mktime(value.timetuple())) * 1000) + 'a'
         elif isinstance(value, Decimal):
-            ret = str(value) + 'c'
+            ret = '{:f}c'.format(value)
         elif isinstance(value, list):
             try:
                 base_cls = type(value[0])


### PR DESCRIPTION
In Python 2, using `str()` to convert `Decimal` and `float` to strings is not safe since by default, it produces scientific notation for numbers far away from 0, whereas OrientDB does not accept scientific notation.

This PR ensures that numbers are represented with as much precision as possible, and adds a test for the serialization of the values `[1e50, 1e-50, 1.23456789012]` to ensure everything works properly.